### PR TITLE
support hadoop3, spark3.5, and GCS connector 3.0.0

### DIFF
--- a/install_gcs_connector.py
+++ b/install_gcs_connector.py
@@ -108,7 +108,6 @@ def parse_args():
     if args.key_file_path and not os.path.isfile(args.key_file_path):
         logging.warning(f"{args.key_file_path} file doesn't exist")
 
-
     if THE_SPARK_VERSION >= (3, 5, 0):
         if args.key_file_path is not None and args.auth_type != "SERVICE_ACCOUNT_JSON_KEYFILE":
             raise ValueError(f"In Spark >=3.5.0, when --key-file-path is specified, --auth-type must be SERVICE_ACCOUNT_JSON_KEYFILE")

--- a/install_gcs_connector.py
+++ b/install_gcs_connector.py
@@ -44,7 +44,7 @@ def spark_version() -> Tuple[int, int, int]:
 THE_SPARK_VERSION = spark_version()
 
 
-def parse_connector_version(version) -> Tuple[int, int, int, int, Union[int, float]]:
+def parse_connector_version(version) -> Tuple[int, int, int, int, Union[int, float], str]:
     """Parse a connector version string into a tuple (hadoop version, major version, minor version, patch version, release candidate)."""
 
     parts = version.split('-')

--- a/install_gcs_connector.py
+++ b/install_gcs_connector.py
@@ -35,8 +35,9 @@ def spark_version() -> Tuple[int, int, int]:
     split = spark_version_string.split('.')
     if len(split) != 3:
         raise ValueError(spark_version_string)
+    major, minor, patch = split
     try:
-        return tuple(int(x) for x in split)
+        return int(major), int(minor), int(patch)
     except ValueError as err:
         raise ValueError(spark_version_string) from err
 
@@ -72,7 +73,7 @@ def parse_connector_version(version) -> Tuple[int, int, int, int, Union[int, flo
 
         major_jar_version, minor_jar_version, patch_jar_version = map(int, jar_version.split('.'))
     except ValueError as err:
-        raise ValueError(f'unexpected version string: {version} {jar_version}') from err
+        raise ValueError(f'unexpected version string: {version}') from err
 
     return (hadoop_version, major_jar_version, minor_jar_version, patch_jar_version, release_candidate or float("inf"), version)
 


### PR DESCRIPTION
The new GCS connector drops support for hadoop <3, changes the version
string, and, most importantly, substantially reduces the memory use of
trivial pipelines. I saw a reduction from >3.75GiB to ~1.3GiB on a
trivial Hail pipeline. I believe this is entirely due to better HTTP
buffer management in the GCS hadoop connector. Without this change,
in combination with Java 11 and Spark 3.5.0, we see a marginal but
meaningful increase in memory use. Enough to fail some of our somewhat
strict memory tests.

I tested this locally on an unreleased version of Hail that uses Spark 3.5.0,
and Java 11.
